### PR TITLE
Fix org search

### DIFF
--- a/lib/PipedrivePUT/organization.rb
+++ b/lib/PipedrivePUT/organization.rb
@@ -101,7 +101,7 @@ require 'rest-client'
 
             content = open(url).read
             parsed = JSON.parse(content)
-            return 'No Organizations returned' if parsed['data'].nil?
+            return table if parsed['data'].nil?
 
             while count < parsed['data'].size
               table[tablesize] = parsed['data'][count]

--- a/lib/PipedrivePUT/organization.rb
+++ b/lib/PipedrivePUT/organization.rb
@@ -45,19 +45,10 @@ require 'rest-client'
 
 
 			#Add an organization
-			def self.addOrganization(companyName, options = {})
-				#args.each_with_index{ |arg, i| puts "#{i+1}. #{arg}" }
-
-				uri = URI.parse('https://api.pipedrive.com/v1/organizations?api_token=' + @@key.to_s)
-
-				if (!options.nil?)
-
-					options.merge!(:name => companyName)
-
-					#puts options
-
-					response = Net::HTTP.post_form(uri, options)
-				end
+			def self.addOrganization(company_name, options = {})
+				uri = "https://api.pipedrive.com/v1/organizations?api_token=#{@@key}"
+				options = options.merge(name: company_name)
+        HTTParty.post(uri, body: options.to_json, headers: {'Content-type' => 'application/json'})
 			end
 
 			#Return data of a specific Organization

--- a/lib/PipedrivePUT/organization.rb
+++ b/lib/PipedrivePUT/organization.rb
@@ -85,7 +85,7 @@ require 'rest-client'
         params[:limit]     = options.fetch(:limit, 500)
         params[:api_token] = @@key.to_s
 
-        url = "https://api.pipedrive.com/v1/organizations/find?term=#{term}"
+        url = "https://api.pipedrive.com/v1/organizations/find?term=#{name}"
 
         params.each do |key, value|
           url << "&#{key}=#{value}"

--- a/lib/PipedrivePUT/organization.rb
+++ b/lib/PipedrivePUT/organization.rb
@@ -13,7 +13,7 @@ require 'rest-client'
 		#Get All Organizations from Pipedrive
 		       def self.getAllOrgs()
 					  @start = 0
-					  
+
 					  table = Array.new
 					  @more_items = true
 					  tablesize = 0
@@ -42,11 +42,11 @@ require 'rest-client'
 					return table
 			end
 
-                        
-                          
+
+
 			#Add an organization
 			def self.addOrganization(companyName, options = {})
-				#args.each_with_index{ |arg, i| puts "#{i+1}. #{arg}" } 
+				#args.each_with_index{ |arg, i| puts "#{i+1}. #{arg}" }
 
 				uri = URI.parse('https://api.pipedrive.com/v1/organizations?api_token=' + @@key.to_s)
 
@@ -77,55 +77,54 @@ require 'rest-client'
 				end
 			end
 
-			#Find Organization by name
-			def self.findOrganizationByName(name)
-				begin
-					@start = 0
-				  
-					table = Array.new
-					@more_items = true
-					tablesize = 0
+      # Find Organization by name
+      def self.findOrganizationByName(name, options = {})
+        params = {}
 
-					while @more_items == true do
-						count = 0
+        params[:start]     = options.fetch(:start, 0)
+        params[:limit]     = options.fetch(:limit, 500)
+        params[:api_token] = @@key.to_s
 
-						@base = URI.parse('https://api.pipedrive.com/v1/organizations/find?term=' + name+ '&start=' + @start.to_s + '&limit=500&api_token=' + @@key.to_s)
-							
-						#puts @base
+        url = "https://api.pipedrive.com/v1/organizations/find?term=#{term}"
 
-						@content = open(@base.to_s).read
+        params.each do |key, value|
+          url << "&#{key}=#{value}"
+        end
 
-							#puts @content
+        begin
+          table = []
+          more_items = true
+          tablesize = 0
 
-							@parsed = JSON.parse(@content)
+          while more_items == true
+            count = 0
 
-							while count < @parsed["data"].size
-								#table.push(@parsed["data"][count])
-								table[tablesize] = @parsed["data"][count]
-								count = count +1
-								tablesize = tablesize + 1
-									
-							end	
-								@pagination = @parsed['additional_data']['pagination']
-								@more_items = @pagination['more_items_in_collection']
-								#puts @more_items
-								@start = @pagination['next_start']
-								#puts @start
-								end
-							return table
+            content = open(url).read
+            parsed = JSON.parse(content)
+            return 'No Organizations returned' if parsed['data'].nil?
 
-				rescue OpenURI::HTTPError => error
-					response = error.io
-					return response.status
-				end
-			end
-			
+            while count < parsed['data'].size
+              table[tablesize] = parsed['data'][count]
+              count += 1
+              tablesize += 1
+            end
+            pagination     = parsed['additional_data']['pagination']
+            more_items     = pagination['more_items_in_collection']
+            params[:start] = pagination['next_start']
+          end
+          return table
+        rescue OpenURI::HTTPError => error
+          response = error.io
+          return response.status
+        end
+      end
+
 
 			#Get Persons of an Organization
 			def self.getPersonsOfOrganization(id)
 				begin
 					@start = 0
-				  
+
 					table = Array.new
 					@more_items = true
 					tablesize = 0
@@ -134,7 +133,7 @@ require 'rest-client'
 						count = 0
 
 						@base = 'https://api.pipedrive.com/v1/organizations/' + id.to_s + '/persons?&start=' + @start.to_s + '&limit=500&api_token=' + @@key.to_s
-											
+
 						@content = open(@base.to_s).read
 
 						puts @content
@@ -144,14 +143,14 @@ require 'rest-client'
 						if @parsed["data"].nil?
 							return "Organization does not have any Person associated with that id"
 						else
-					
+
 								while count < @parsed["data"].size
 									#table.push(@parsed["data"][count])
 									table[tablesize] = @parsed["data"][count]
 									count = count +1
 									tablesize = tablesize + 1
-						
-								end	
+
+								end
 							@pagination = @parsed['additional_data']['pagination']
 							@more_items = @pagination['more_items_in_collection']
 							#puts @more_items
@@ -171,18 +170,18 @@ require 'rest-client'
 				@url = 'https://api.pipedrive.com/v1/organizations/' + id.to_s + '?api_token=' + @@key.to_s
 
 				#puts @url
-				
+
 				if (!options.nil?)
-					
+
 					options.merge!(:id => id)
 					#puts options
 
 					#puts '----------------------'
-					
+
 					response = HTTParty.put(@url.to_s, :body => options.to_json, :headers => {'Content-type' => 'application/json'})
 					#puts '----------------------'
-					#puts response				
-	
+					#puts response
+
 				end
 
 			end

--- a/lib/PipedrivePUT/persons.rb
+++ b/lib/PipedrivePUT/persons.rb
@@ -102,7 +102,7 @@ module PipedrivePUT
 
         content = open(url).read
         parsed = JSON.parse(content)
-        return 'No Persons returned' if parsed['data'].nil?
+        return table if parsed['data'].nil?
 
         while count < parsed['data'].size
           table[tablesize] = parsed['data'][count]

--- a/lib/PipedrivePUT/persons.rb
+++ b/lib/PipedrivePUT/persons.rb
@@ -109,9 +109,9 @@ module PipedrivePUT
           count += 1
           tablesize += 1
         end
-        pagination       = parsed['additional_data']['pagination']
-        more_items       = pagination['more_items_in_collection']
-        params['start'] = pagination['next_start']
+        pagination     = parsed['additional_data']['pagination']
+        more_items     = pagination['more_items_in_collection']
+        params[:start] = pagination['next_start']
       end
       table
     end


### PR DESCRIPTION
some refactoring +
- I made the createOrg call use HTTParty as well to be consistent with the way that createPerson works (its useful to the get the pipedriveId in the response)
- search for person / organization now returns an empty array rather than a string if there are no results. This means that you always get back a collection. i.e. if results.any? then do something else not.

I can't see the benefit of returning a string when there are no results.

feedback welcome

cheers

kev
