### PR TITLE
Return errors on missing search term

### DIFF
--- a/lib/PipedrivePUT/organization.rb
+++ b/lib/PipedrivePUT/organization.rb
@@ -72,15 +72,12 @@ require 'rest-client'
       def self.findOrganizationByName(name, options = {})
         params = {}
 
+        params[:term]      = name if name && !name.empty?
         params[:start]     = options.fetch(:start, 0)
         params[:limit]     = options.fetch(:limit, 500)
         params[:api_token] = @@key.to_s
 
-        url = "https://api.pipedrive.com/v1/organizations/find?term=#{name}"
-
-        params.each do |key, value|
-          url << "&#{key}=#{value}"
-        end
+        url = "https://api.pipedrive.com/v1/organizations/find?#{URI.encode_www_form(params)}"
 
         begin
           table = []

--- a/lib/PipedrivePUT/persons.rb
+++ b/lib/PipedrivePUT/persons.rb
@@ -97,8 +97,7 @@ module PipedrivePUT
       while more_items == true
         count = 0
 
-        content = open(url).read
-        parsed = JSON.parse(content)
+        parsed = HTTParty.get(url)
         return table if parsed['data'].nil?
 
         while count < parsed['data'].size

--- a/lib/PipedrivePUT/persons.rb
+++ b/lib/PipedrivePUT/persons.rb
@@ -85,17 +85,14 @@ module PipedrivePUT
       params = {}
 
       # optional search parameters
+      params[:term]            = term if term && !term.empty?
       params[:start]           = options.fetch(:start, 0)
       params[:org_id]          = options.fetch(:org_id, nil) if params[:org_id]
       params[:limit]           = options.fetch(:limit, 500)
       params[:search_by_email] = options.fetch(:search_by_email, 0)
       params[:api_token]       = @@key.to_s
 
-      url = "https://api.pipedrive.com/v1/persons/find?term=#{term}"
-
-      params.each do |key, value|
-        url << "&#{key}=#{value}"
-      end
+      url = "https://api.pipedrive.com/v1/persons/find?#{URI.encode_www_form(params)}"
 
       while more_items == true
         count = 0


### PR DESCRIPTION
currently if you do not provide a term you get an exception - but the Pipedrive API actually still returns a JSON object

This change means you can still parse the official API response
